### PR TITLE
fix: 🐛 Make code go<1.12 compatible

### DIFF
--- a/oss_formatter.go
+++ b/oss_formatter.go
@@ -58,7 +58,7 @@ func (f *OSSFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 }
 
 func replaceInvalidChars(content string) string {
-	return strings.ReplaceAll(content, ".", "_")
+	return strings.Replace(content, ".", "_", -1)
 }
 
 var _ logrus.Formatter = (*OSSFormatter)(nil)


### PR DESCRIPTION
`strings.ReplaceAll` is a new method in the go standard library added in
1.12. To maintain backward compatibility, we use `strings.Replace` with
`n=-1` (If n < 0, there is no limit on the number of replacements - from
godoc)

Signed-off-by: Emmanuel Goh <emmanuel@visenze.com>