### PR TITLE
[API-1201] Quote empty strings when logged

### DIFF
--- a/text_formatter.go
+++ b/text_formatter.go
@@ -130,6 +130,9 @@ func (f *TextFormatter) printColored(b *bytes.Buffer, entry *Entry, keys []strin
 }
 
 func needsQuoting(text string) bool {
+	if len(text) == 0 {
+		return true
+	}
 	for _, ch := range text {
 		if !((ch >= 'a' && ch <= 'z') ||
 			(ch >= 'A' && ch <= 'Z') ||


### PR DESCRIPTION
Previous behavior allows empty strings to be logged as `vtt_source=` but this is not well-parsed by
ES and BigQuery, so we need to log it as `vtt_source=""`

BREAKING CHANGE: Previously null strings will now become empty strings